### PR TITLE
Update scripts.js

### DIFF
--- a/lesson-2-document-object-model/exercises/starter/js/scripts.js
+++ b/lesson-2-document-object-model/exercises/starter/js/scripts.js
@@ -15,7 +15,8 @@ function executeQuery(query) {
 
 function sanitizeQuery(input) {
     // Remove anything that's not alphanumeric, spaces, or specific allowed characters
-    const sanitized = input.replace(/[^a-zA-Z0-9\s\.\[\]"'=()]/g, '');
+    const sanitized = input.replace(/[^a-zA-Z0-9\s\.\[\]"'=()-]/g, '');
+    // previous sanitized variable would not allow the dash in data-questNum so the question always failed
 
     // Ensure the query starts with 'document.querySelector' or 'document.querySelectorAll'
     if (!sanitized.startsWith('document.querySelector') && !sanitized.startsWith('document.querySelectorAll')) {


### PR DESCRIPTION
Question five is being sanitized, but the regex is removing the dash.

The correct answer is "document.querySelector('div[data-questnum="five"] p')" but the sanitized input sent to the script is "document.querySelector('div[dataquestnum="five"] p')"

This pull request fixes the regex to allow the dash.